### PR TITLE
get_temp_dir() instead of sys_get_temp_dir()

### DIFF
--- a/includes/classes/class-wcj-pdf-invoice.php
+++ b/includes/classes/class-wcj-pdf-invoice.php
@@ -254,7 +254,7 @@ class WCJ_PDF_Invoice extends WCJ_Invoice {
 		// Close and output PDF document
 		$result_pdf = $pdf->Output( '', 'S' );
 		$file_name = $this->get_file_name();
-		$file_path = sys_get_temp_dir() . '/' . $file_name;
+		$file_path = get_temp_dir() . '/' . $file_name;
 		if ( ! file_put_contents( $file_path, $result_pdf ) )
 			return null;
 

--- a/includes/pdf-invoices/settings/class-wcj-pdf-invoicing-header.php
+++ b/includes/pdf-invoices/settings/class-wcj-pdf-invoicing-header.php
@@ -51,7 +51,7 @@ class WCJ_PDF_Invoicing_Header {
 					'default'  => '',
 					'type'     => 'text',
 					'css'      => 'width:33%;min-width:300px;',
-					'desc'     => __( 'Enter a URL to an image you want to show in the invoice\'s header. Upload your image using the <a href="/wp-admin/media-new.php">media uploader</a>.', 'woocommerce-jetpack' ),
+					'desc'     => sprintf( __( 'Enter a URL to an image you want to show in the email\'s header. Upload your image using the <a href="%s">media uploader</a>.', 'woocommerce-jetpack' ), admin_url( 'media-new.php' ) ),
 					'desc_tip' => __( 'Leave blank to disable', 'woocommerce-jetpack' ),								
 				),	
 


### PR DESCRIPTION
get_temp_dir() returns WC_TEMP_DIR of wp_config.php (if set). Helpfull often on shared hosts, where /tmp is not writeable
